### PR TITLE
Changed service from "serviceC" to "master"

### DIFF
--- a/app/models/User.scala
+++ b/app/models/User.scala
@@ -27,7 +27,7 @@ case class User(
 
 object User {
 
-  val services = Seq("serviceA", "serviceB", "serviceC")
+  val services = Seq("serviceA", "serviceB", "master")
 
   val users = scala.collection.mutable.HashMap[Long, User](
     1L -> User(Some(1L), "master@myweb.com", true, (new BCryptPasswordHasher()).hash("123123").password, "Eddy", "Eddard", "Stark", List("master")),


### PR DESCRIPTION
I changed the last service to read master instead of serviceC per the documentation. It didn't make sense to have "serviceC" as an option when signing up, as it was not discussed in other parts of the documentation.