### PR TITLE
Remember original deep link after authentication.

### DIFF
--- a/app/controllers/Auth.scala
+++ b/app/controllers/Auth.scala
@@ -159,12 +159,14 @@ class Auth @Inject() (
       formWithErrors => Future.successful(BadRequest(viewsAuth.signIn(formWithErrors))),
       formData => {
         val (identifier, password, rememberMe) = formData
+        val entryUri = request.cookies.get("ENTRY_URI").map(_.value)
+        val targetUri: String = entryUri.getOrElse(routes.Application.index.toString)
         credentialsProvider.authenticate(Credentials(identifier, password)).flatMap { loginInfo =>
           userService.retrieve(loginInfo).flatMap {
             case Some(user) => for {
               authenticator <- env.authenticatorService.create(loginInfo).map(authenticatorWithRememberMe(_, rememberMe))
               cookie <- env.authenticatorService.init(authenticator)
-              result <- env.authenticatorService.embed(cookie, Redirect(routes.Application.index))
+              result <- env.authenticatorService.embed(cookie, Redirect(targetUri).discardingCookies(DiscardingCookie("ENTRY_URI")))
             } yield {
               env.eventBus.publish(LoginEvent(user, request))
               result

--- a/app/utils/ErrorHandler.scala
+++ b/app/utils/ErrorHandler.scala
@@ -22,7 +22,8 @@ class ErrorHandler @Inject() (
 
   // 401 - Unauthorized
   override def onNotAuthenticated(implicit request: RequestHeader): Future[Result] = Future.successful {
-    Redirect(routes.Auth.signIn)
+    val entryUri = request.uri
+    Redirect(routes.Auth.signIn).withCookies(Cookie("ENTRY_URI", entryUri))
   }
 
   // 403 - Forbidden

--- a/app/utils/ErrorHandler.scala
+++ b/app/utils/ErrorHandler.scala
@@ -22,8 +22,7 @@ class ErrorHandler @Inject() (
 
   // 401 - Unauthorized
   override def onNotAuthenticated(implicit request: RequestHeader): Future[Result] = Future.successful {
-    val entryUri = request.uri
-    Redirect(routes.Auth.signIn).withCookies(Cookie("ENTRY_URI", entryUri))
+    Redirect(routes.Auth.signIn).withSession(request.session + ("ENTRY_URI" -> request.uri))
   }
 
   // 403 - Forbidden


### PR DESCRIPTION
After a successfull authentication, the user is not always redirected to the index page. Before this change, the user was always redirected to the index page after authentication, even if he opened the application with a link that was not the index page.

The new behaviour works as follows:
If the user tried to open a page different than the index page, this page is opened after authentication.
If the user just clicked the SignIn link directly, the index page is opened as a default.

As discussed here: https://github.com/adrianhurt/play-silhouette-credentials-seed/issues/6